### PR TITLE
changed "$*" command in batch file to "%*"

### DIFF
--- a/cointrader.bat
+++ b/cointrader.bat
@@ -1,1 +1,1 @@
-java -jar target/cointrader-0.3.0-SNAPSHOT-jar-with-dependencies.jar $*
+java -jar target/cointrader-0.3.0-SNAPSHOT-jar-with-dependencies.jar %*


### PR DESCRIPTION
Running the batch script was throwing a "Expected a command, got $_"  message
Replacing "$_" with "%*" in the batch script fixes the problem
